### PR TITLE
[Huey] Chapter 5. 프로젝트 세팅하기 - API 응답 통일, 에러 핸들러

### DIFF
--- a/src/main/java/com/example/umc10th/domain/member/controller/AuthController.java
+++ b/src/main/java/com/example/umc10th/domain/member/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.example.umc10th.domain.member.controller;
+
+import com.example.umc10th.domain.member.dto.MemberReqDTO;
+import com.example.umc10th.domain.member.dto.MemberResDTO;
+import com.example.umc10th.domain.member.exception.code.MemberSuccessCode;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+    //회원가입
+    @PostMapping("/signup")
+    public ApiResponse<MemberResDTO.SignUpDTO> signUp(
+            @RequestBody MemberReqDTO.SignUpDTO request
+    ) {
+        return ApiResponse.onSuccess(MemberSuccessCode.SIGN_UP_SUCCESS, null);
+    }
+
+
+
+}

--- a/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/umc10th/domain/member/controller/MemberController.java
@@ -1,4 +1,6 @@
 package com.example.umc10th.domain.member.controller;
 
+
 public class MemberController {
+
 }

--- a/src/main/java/com/example/umc10th/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/member/dto/MemberReqDTO.java
@@ -1,4 +1,22 @@
 package com.example.umc10th.domain.member.dto;
 
+import com.example.umc10th.domain.member.enums.Gender;
+import lombok.Getter;
+import java.time.LocalDate;
+import java.util.List;
+
 public class MemberReqDTO {
+    //회원가입
+    @Getter
+    public static class SignUpDTO {
+        String id;
+        String password;
+        String name;
+        Gender gender;
+        LocalDate birthDate;
+        String address;
+        String email;
+        String phoneNumber;
+        List<String> favoriteFood;
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/member/dto/MemberResDTO.java
@@ -1,4 +1,12 @@
 package com.example.umc10th.domain.member.dto;
 
+import lombok.Builder;
+
 public class MemberResDTO {
+    //회원가입
+    @Builder
+    public record SignUpDTO(
+            Long memberId
+    ) {}
+
 }

--- a/src/main/java/com/example/umc10th/domain/member/enums/Gender.java
+++ b/src/main/java/com/example/umc10th/domain/member/enums/Gender.java
@@ -1,4 +1,7 @@
 package com.example.umc10th.domain.member.enums;
 
 public enum Gender {
+    MALE,
+    FEMALE,
+    NONE
 }

--- a/src/main/java/com/example/umc10th/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/member/exception/code/MemberErrorCode.java
@@ -1,4 +1,19 @@
 package com.example.umc10th.domain.member.exception.code;
 
-public enum MemberErrorCode {
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "해당 사용자를 찾을 수 없습니다."),
+    MEMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER400_1", "이미 가입된 사용자입니다."),
+    INVALID_MEMBER_INFO(HttpStatus.BAD_REQUEST, "MEMBER400_2", "잘못된 회원 정보입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/member/exception/code/MemberSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/member/exception/code/MemberSuccessCode.java
@@ -1,4 +1,17 @@
 package com.example.umc10th.domain.member.exception.code;
 
-public enum MemberSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberSuccessCode implements BaseSuccessCode {
+
+    SIGN_UP_SUCCESS(HttpStatus.OK, "MEMBER200_1", "회원가입이 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/example/umc10th/domain/mission/controller/MissionController.java
@@ -1,4 +1,42 @@
 package com.example.umc10th.domain.mission.controller;
 
+import com.example.umc10th.domain.mission.dto.MissionReqDTO;
+import com.example.umc10th.domain.mission.dto.MissionResDTO;
+import com.example.umc10th.domain.mission.exception.code.MissionSuccessCode;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missions")
 public class MissionController {
+
+    // 1. 홈화면 미션 목록 조회
+    @GetMapping
+    public ApiResponse<List<MissionResDTO.MissionDTO>> getMissions(
+            @RequestParam Long regionId
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.GET_MISSIONS_SUCCESS, null);
+    }
+
+    // 2. 내 미션 목록 조회 (진행중/완료)
+    @GetMapping("/me")
+    public ApiResponse<List<MissionResDTO.MissionDTO>> getMyMissions(
+            @RequestParam String status
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.GET_MY_MISSIONS_SUCCESS, null);
+    }
+
+    // 3. 미션 성공 요청
+    @PatchMapping("/{missionId}/status")
+    public ApiResponse<MissionResDTO.StatusUpdateDTO> updateMissionStatus(
+            @PathVariable Long missionId,
+            @RequestBody @Valid MissionReqDTO.StatusUpdateDTO request
+    ) {
+        return ApiResponse.onSuccess(MissionSuccessCode.UPDATE_MISSION_STATUS_SUCCESS, null);
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionReqDTO.java
@@ -1,4 +1,11 @@
 package com.example.umc10th.domain.mission.dto;
 
+import lombok.Getter;
+
 public class MissionReqDTO {
+
+    @Getter
+    public static class StatusUpdateDTO {
+        String status;
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/mission/dto/MissionResDTO.java
@@ -1,4 +1,24 @@
 package com.example.umc10th.domain.mission.dto;
 
+import lombok.Builder;
+
 public class MissionResDTO {
+
+    // 홈화면 미션 목록, 미션 목록 조회 응답
+    @Builder
+    public record MissionDTO(
+            Long missionId,
+            String storeName,
+            String missionContent,
+            Integer reward,
+            String status,
+            Integer dDay
+    ) {}
+
+    // 미션 상태 변경 응답
+    @Builder
+    public record StatusUpdateDTO(
+            Long missionId,
+            String status
+    ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionErrorCode.java
@@ -1,4 +1,19 @@
 package com.example.umc10th.domain.mission.exception.code;
 
-public enum MissionErrorCode {
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MissionErrorCode implements BaseErrorCode {
+
+    MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404_1", "해당 미션을 찾을 수 없습니다."),
+    MISSION_ALREADY_COMPLETE(HttpStatus.BAD_REQUEST, "MISSION400_1", "이미 완료된 미션입니다."),
+    MISSION_NOT_CHALLENGING(HttpStatus.BAD_REQUEST, "MISSION400_2", "진행중인 미션이 아닙니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/mission/exception/code/MissionSuccessCode.java
@@ -1,4 +1,19 @@
 package com.example.umc10th.domain.mission.exception.code;
 
-public enum MissionSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MissionSuccessCode implements BaseSuccessCode {
+
+    GET_MISSIONS_SUCCESS(HttpStatus.OK, "MISSION200_1", "미션 목록 조회가 완료되었습니다."),
+    GET_MY_MISSIONS_SUCCESS(HttpStatus.OK, "MISSION200_2", "내 미션 목록 조회가 완료되었습니다."),
+    UPDATE_MISSION_STATUS_SUCCESS(HttpStatus.OK, "MISSION200_3", "미션 성공 요청이 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/example/umc10th/domain/review/controller/ReviewController.java
@@ -1,4 +1,28 @@
 package com.example.umc10th.domain.review.controller;
 
+import com.example.umc10th.domain.review.dto.ReviewReqDTO;
+import com.example.umc10th.domain.review.dto.ReviewResDTO;
+import com.example.umc10th.domain.review.exception.code.ReviewSuccessCode;
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.RequestToViewNameTranslator;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reviews")
+
 public class ReviewController {
+
+    @PostMapping("/{storeId}")
+    public ApiResponse<ReviewResDTO.CreateReviewDTO> createReview(
+            @PathVariable Long storeId,
+            @RequestBody ReviewReqDTO.CreativeReviewDTO request
+    ){
+        return ApiResponse.onSuccess(ReviewSuccessCode.CREATE_REVIEW_SUCCESS, null);
+    }
+
+
+
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewReqDTO.java
@@ -1,4 +1,12 @@
 package com.example.umc10th.domain.review.dto;
 
+import lombok.Getter;
+import org.springframework.web.bind.annotation.GetMapping;
+
 public class ReviewReqDTO {
+    @Getter
+    public static class CreativeReviewDTO {
+        Float score;
+        String reviewContent;
+    }
 }

--- a/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/example/umc10th/domain/review/dto/ReviewResDTO.java
@@ -1,4 +1,15 @@
 package com.example.umc10th.domain.review.dto;
 
+import lombok.Builder;
+
+import java.time.LocalDate;
+
 public class ReviewResDTO {
+    @Builder
+    public record CreateReviewDTO(
+            Long reviewId,
+            Float score,
+            String reviewContent,
+            LocalDate createdAt
+    ) {}
 }

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewErrorCode.java
@@ -1,4 +1,18 @@
 package com.example.umc10th.domain.review.exception.code;
 
-public enum ReviewErrorCode {
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW404_1", "해당 리뷰를 찾을 수 없습니다."),
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "REVIEW400_1", "이미 작성한 리뷰가 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/review/exception/code/ReviewSuccessCode.java
@@ -1,4 +1,17 @@
 package com.example.umc10th.domain.review.exception.code;
 
-public enum ReviewSuccessCode {
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewSuccessCode implements BaseSuccessCode {
+
+    CREATE_REVIEW_SUCCESS(HttpStatus.OK, "REVIEW200_1", "리뷰 작성이 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/example/umc10th/domain/store/controller/StoreController.java
+++ b/src/main/java/com/example/umc10th/domain/store/controller/StoreController.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.controller;
+package com.example.umc10th.domain.store.controller;
 
 public class StoreController {}

--- a/src/main/java/com/example/umc10th/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/example/umc10th/domain/store/converter/StoreConverter.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.converter;
+package com.example.umc10th.domain.store.converter;
 
 public class StoreConverter {}

--- a/src/main/java/com/example/umc10th/domain/store/dto/StoreRequestDTO.java
+++ b/src/main/java/com/example/umc10th/domain/store/dto/StoreRequestDTO.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.dto;
+package com.example.umc10th.domain.store.dto;
 
 public class StoreRequestDTO {}

--- a/src/main/java/com/example/umc10th/domain/store/dto/StoreResponseDTO.java
+++ b/src/main/java/com/example/umc10th/domain/store/dto/StoreResponseDTO.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.dto;
+package com.example.umc10th.domain.store.dto;
 
 public class StoreResponseDTO {}

--- a/src/main/java/com/example/umc10th/domain/store/entity/Location.java
+++ b/src/main/java/com/example/umc10th/domain/store/entity/Location.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.entity;
+package com.example.umc10th.domain.store.entity;
 
 public class Location {}

--- a/src/main/java/com/example/umc10th/domain/store/entity/Store.java
+++ b/src/main/java/com/example/umc10th/domain/store/entity/Store.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.entity;
+package com.example.umc10th.domain.store.entity;
 
 public class Store {}

--- a/src/main/java/com/example/umc10th/domain/store/exception/StoreException.java
+++ b/src/main/java/com/example/umc10th/domain/store/exception/StoreException.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.exception;
+package com.example.umc10th.domain.store.exception;
 
 public class StoreException extends RuntimeException {}

--- a/src/main/java/com/example/umc10th/domain/store/exception/code/StoreErrorCode.java
+++ b/src/main/java/com/example/umc10th/domain/store/exception/code/StoreErrorCode.java
@@ -1,3 +1,19 @@
-﻿package com.example.umc10th.domain.store.exception.code;
+package com.example.umc10th.domain.store.exception.code;
 
-public enum StoreErrorCode {}
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StoreErrorCode implements BaseErrorCode {
+
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404_1", "해당 가게를 찾을 수 없습니다."),
+    STORE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "STORE400_1", "이미 존재하는 가게입니다."),
+    INVALID_STORE_INFO(HttpStatus.BAD_REQUEST, "STORE400_2", "잘못된 가게 정보입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/store/exception/code/StoreSuccessCode.java
+++ b/src/main/java/com/example/umc10th/domain/store/exception/code/StoreSuccessCode.java
@@ -1,3 +1,18 @@
-﻿package com.example.umc10th.domain.store.exception.code;
+package com.example.umc10th.domain.store.exception.code;
 
-public enum StoreSuccessCode {}
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StoreSuccessCode implements BaseSuccessCode {
+
+    GET_STORES_SUCCESS(HttpStatus.OK, "STORE200_1", "가게 목록 조회가 완료되었습니다."),
+    GET_STORE_SUCCESS(HttpStatus.OK, "STORE200_2", "가게 상세 조회가 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/domain/store/repository/RegionRepository.java
+++ b/src/main/java/com/example/umc10th/domain/store/repository/RegionRepository.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.repository;
+package com.example.umc10th.domain.store.repository;
 
 public interface RegionRepository {}

--- a/src/main/java/com/example/umc10th/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/example/umc10th/domain/store/repository/StoreRepository.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.repository;
+package com.example.umc10th.domain.store.repository;
 
 public interface StoreRepository {}

--- a/src/main/java/com/example/umc10th/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/umc10th/domain/store/service/StoreService.java
@@ -1,3 +1,3 @@
-﻿package com.example.umc10th.domain.store.service;
+package com.example.umc10th.domain.store.service;
 
 public class StoreService {}

--- a/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.example.umc10th.global.apiPayload;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.code.BaseSuccessCode;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+
+    @JsonProperty("code")
+    private final String code;
+
+    @JsonProperty("message")
+    private final String message;
+
+    @JsonProperty("result")
+    private T result;
+
+    // 성공한 경우
+    public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
+        return new ApiResponse<>(true, code.getCode(), code.getMessage(), result);
+    }
+
+
+    // 실패한 경우
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T result) {
+        return new ApiResponse<>(false, code.getCode(), code.getMessage(), result);
+    }
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,9 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/BaseSuccessCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/BaseSuccessCode.java
@@ -1,0 +1,9 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseSuccessCode {
+    HttpStatus getStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralErrorCode.java
@@ -1,0 +1,25 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter //BaseErrorCode 자동구현
+@AllArgsConstructor
+public enum GeneralErrorCode implements BaseErrorCode {
+
+    // 400
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400_1", "잘못된 요청입니다."),
+    // 401
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401_1", "인증되지 않았습니다."),
+    // 403
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403_1", "접근이 금지되었습니다."),
+    // 404
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404_1", "해당 리소스를 찾을 수 없습니다."),
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500_1", "서버 에러가 발생했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralSuccessCode.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/code/GeneralSuccessCode.java
@@ -1,0 +1,16 @@
+package com.example.umc10th.global.apiPayload.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GeneralSuccessCode implements BaseSuccessCode {
+
+    OK(HttpStatus.OK, "COMMON200_1", "성공적으로 요청을 처리했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/exception/GeneralException.java
@@ -1,0 +1,15 @@
+package com.example.umc10th.global.apiPayload.exception;
+
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+
+@Getter
+public class GeneralException extends RuntimeException {
+
+    private final BaseErrorCode errorCode;
+
+    public GeneralException(BaseErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/example/umc10th/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -1,0 +1,29 @@
+package com.example.umc10th.global.apiPayload.handler;
+
+import com.example.umc10th.global.apiPayload.ApiResponse;
+import com.example.umc10th.global.apiPayload.code.BaseErrorCode;
+import com.example.umc10th.global.apiPayload.code.GeneralErrorCode;
+import com.example.umc10th.global.apiPayload.exception.GeneralException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GeneralExceptionAdvice {
+
+    // 프로젝트에서 발생한 예외 처리
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ApiResponse<Void>> handleGeneralException(GeneralException e) {
+        BaseErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(ApiResponse.onFailure(errorCode, null));
+    }
+
+    // 그 외 정의되지 않은 모든 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<String>> handleException(Exception e) {
+        BaseErrorCode code = GeneralErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(code.getStatus())
+                .body(ApiResponse.onFailure(code, e.getMessage()));
+    }
+}


### PR DESCRIPTION
<!--
  제목은 `[닉네임] 챕터 제목` 로 작성해 주세요.
  예시: [Angela] Chapter 1. 서버란 무엇인가(소켓&멀티 프로세스)
-->
close #9 
## ✅ 워크북 체크리스트

- [x] 모든 핵심 키워드 정리를 마쳤나요?
- [x] 핵심 키워드에 대해 완벽히 이해하셨나요?
- [x] 이론 학습 이후 직접 실습을 해보는 시간을 가졌나요?
- [x] 미션을 수행하셨나요?
- [x] 미션을 기록하셨나요?
<br>

## ✅ 컨벤션 체크리스트

- [x] 디렉토리 구조 컨벤션을 잘 지켰나요?
- [x] pr 제목을 컨벤션에 맞게 작성하였나요?
- [x] pr에 해당되는 이슈를 연결하였나요?
- [x] 적절한 라벨을 설정하였나요?
- [x] 스터디원들에게 code review를 요청하기 위해 reviewer를 등록하였나요?
- [x] 닉네임/main 브랜치의 최신 상태를 반영하고 있는지 확인했나요?
<br>

## 📌 주안점

<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분을 설명합니다.
--> 멤버 안에서도 인증관련 부분을 따로 분리해서 AuthController를 새로 만들었는데 어떤가요!! 나중에 회원 정보 관련된 것들과 섞이면 복잡해질 것 같아서 분리해보았습니다. 그리고 맨 처음에 미션 목록 조회 api를 PATCH/member/missions/{missionId}/status 라고 만들었었는데, 이 api는 mission 도메인에서 관리하는 게 맞을 것 같아서 PATCH/missions/{missionId}/status로 바꾸고 MissionController에 작성해보았습니다!
